### PR TITLE
more robust output parsing code

### DIFF
--- a/evaluation/utils_general.py
+++ b/evaluation/utils_general.py
@@ -13,10 +13,12 @@ def evaluate_score(args):
     execution_results = []
     for g in gs:
         if mode == "input" and "f(" not in g:
-            execution_results.append(False)
+            pass
         elif mode == "output" and f"f({i})" in g:
-            execution_results.append(False)
+            pass
         else:
             code_to_execute = f"{c}\nassert {o} == {g}"
             execution_results.append(check_correctness(code_to_execute, 3))
+    if True not in execution_results:
+        execution_results = [False] * len(gs)
     return execution_results

--- a/inference/tasks/input_prediction.py
+++ b/inference/tasks/input_prediction.py
@@ -47,8 +47,8 @@ class InputPrediction(Task):
                 generation = generation.split("[ANSWER]")[1].strip()
         if "==" in generation:
             generation = generation.split("==")[0].strip()
-        if "assert" in generation:
-            generation = generation.split("assert")[1].strip()
+        if "assert f" in generation:
+            generation = "f" + generation.split("assert f")[1].strip()
         return generation.strip()
 
     def process_results(self, generations, references):

--- a/openai/openai_prompt.py
+++ b/openai/openai_prompt.py
@@ -27,8 +27,8 @@ def extract_answer_direct_output(gen):
 def extract_answer_direct_input(gen):
     if "==" in gen:
         gen = gen.split("==")[0].strip()
-    if "assert" in gen:
-        gen = gen.split("assert")[1].strip()
+    if "assert f" in gen:
+        gen = "f" + gen.split("assert f")[1].strip()
     return gen.strip()
 
 def extract_answer_cot_input(gen):
@@ -36,8 +36,8 @@ def extract_answer_cot_input(gen):
         gen = gen.split("[ANSWER]")[1].strip()
         if "==" in gen:
             gen = gen.split("==")[0]
-        if "assert" in gen:
-            gen = gen.split("assert")[1].strip()
+        if "assert f" in gen:
+            gen = "f" + gen.split("assert f")[1].strip()
         return gen.strip()
     else:
         return gen.split('\n')[-1].strip()


### PR DESCRIPTION
1. If models don't output something of the correct format (e.g. rambling CoT with no answer), omit the generation rather than count it as incorrect.
2. Better parsing for input prediction, splitting by "assert f" instead of "assert". This is so that if "assert" happens to be in the CoT, the parsing won't fail.